### PR TITLE
add code of conduct

### DIFF
--- a/_2017_pages/code_of_conduct.md
+++ b/_2017_pages/code_of_conduct.md
@@ -1,0 +1,189 @@
+---
+layout: 2017_default
+title: PyMCon Code of Conduct
+permalink: /code_of_conduct
+---
+
+# Code of Conduct
+
+PyMCon abides by the NumFOCUS Code of Conduct.
+
+<style>.centered {text-align: center;}</style>
+<div class="centered">
+  <a href="https://numfocus.typeform.com/to/kMgloi8t">
+    <button type="button" class="btn btn-warning btn-lg">Report a Code of Conduct Incident</button>
+  </a>
+</div>
+
+We value the participation of each member of the PyMC community and want all attendees to
+have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to
+show respect and courtesy to other attendees throughout the conference and at all
+conference events, whether officially sponsored by PyMC or not.
+
+To make clear what is expected, all delegates, speakers, exhibitors and volunteers at
+PyMCon event are required to conform to the NumFOCUS Code of Conduct. Organizers will
+enforce this code throughout the event.
+
+We reproduce here certain portions of the NumFOCUS Code of Conduct that are specifically
+relevant to PyMCon. We encourage all PyMCon participants to review the complete
+Code of Conduct.
+
+## The Shorter Version
+
+Be kind to others. Do not insult or put down others. Behave professionally. Remember that
+harassment and sexist, racist, or exclusionary jokes and language are not appropriate for
+PyMCon.
+
+All communication should be appropriate for a professional audience including people of
+many different backgrounds. Sexual language and imagery is not appropriate.
+
+PyMCon is dedicated to providing a harassment-free event experience for everyone,
+regardless of gender, sexual orientation, gender identity, and expression, disability,
+physical appearance, body size, race, or religion. We do not tolerate harassment of
+participants in any form.
+
+Thank you for helping make this a welcoming, friendly community for all.
+
+## Code of Conduct Highlights Specific to PyMCon
+
+We reproduce here certain portions of the NumFOCUS Code of Conduct that are specifically
+relevant to PyMCon. We encourage all PyMCon participants to review the complete Code of
+Conduct.
+
+### How to Report
+
+If you believe someone is violating the Code of Conduct, please report this in a timely
+manner. Code of Conduct violations reduce the value of the community for everyone and we
+take them seriously.
+
+You can make a personal or anonymous report by:
+
+* **By Email**: Send a message to any or all Diversity Chairs, which can be reached at
+  oriol.abril.pla@gmail.com and andorra.alexandre@gmail.com. Event organizers will respond
+  promptly.
+* **On Slack**: Join the [PyMCon Slack](https://pymcon.slack.com/join/shared_invite/zt-fk9efmvb-SWvT01TOnykgzFmLgn1iAw)
+  and contact with the Diversity Chairs, Oriol Abril or Alex Andorra.
+* **Online Form**: A variant of the NumFOCUS Code of Conduct Report is available for
+  PyMCon [here](https://numfocus.typeform.com/to/kMgloi8t) (your name and contact
+  information are not required).
+
+During PyMCon, we recommend contacting via email or Slack so we can take
+immediate action if necessary. In addition to contacting directly with the Diversity
+committee, we also encourages you to make a report using our reporting form.
+
+To file a report anonymously please use the [online form](https://numfocus.typeform.com/to/kMgloi8t).
+
+### What to include in a report
+
+Our ability to address any Code of Conduct breaches in a timely and effective manner
+is impacted by the amount of information you can provide, so our reporting form asks you
+to include as much of the following information as you can:
+
+* Your contact info (so we can get in touch with you if we need to follow up). This will
+  be kept confidential. If you wish to remain anonymous, your information will not be
+  shared beyond the person receiving the initial report.
+* The approximate time and location of the incident (please be as specific as possible)
+* Identifying information (e.g. name, nickname, screen name, physical description) of the
+  individual whose behavior is being reported
+* Description of the behavior (if reporting harassing language, please be specific about
+  the words used), your account of what happened, and any available supporting records
+  (e.g. email, GitHub issue, screenshots, etc.). The online form supports
+  attaching up to 5 files and email and Slack have not limit.
+* Description of the circumstances/context surrounding the incident. Let us know if the
+  incident is ongoing, and/or if this is part of an ongoing pattern of behavior
+* Names and contact info, if possible, of anyone else who witnessed or was involved in
+  this incident. (Did anyone else observe the incident?)
+* Any other relevant information you believe we should have
+
+_The Diversity committee will attempt to gather and write down the above information from
+anyone making a verbal report. Recording the details in writing is exceedingly important
+in order for us to effectively respond to reports. If event staff write down a report
+taken verbally, then the person making the report will be asked to review the written
+report for accuracy._
+
+### Enforcement
+
+At PyMCon, if a participant engages in behavior that violates the Code of Conduct, the
+conference organizers and staff may take any action they deem appropriate.
+
+Potential consequences for violating the NumFOCUS Code of Conduct at PyMCon include:
+
+* Warning the person to cease their behavior and that any further reports will result in
+  sanctions
+* Requiring that the person avoid any interaction with the person they are harassing for
+  the remainder of the event
+* Ending a talk that violates the policy early
+* Not publishing the video or slides of a talk that violated the policy
+* Not allowing a speaker who violated the policy to give (further) talks at the event
+  now or in the future
+* Immediately ending any event volunteer responsibilities and privileges the reported
+  person holds
+* Requiring that the person not volunteer for future events (either indefinitely or for
+  a certain time period)
+* Expelling the person from the event without a refund
+* Banning the person from future events (either indefinitely or for a certain time period)
+* Any other response that the organizing committee deems necessary and appropriate to
+  the situation
+
+### Person(s) Responsible for Resolving Complaints
+
+All reports of breaches of the code of conduct will be investigated and handled by the
+PyMCon Diversity Committee, consulting the NumFOCUS Code of Conduct Enforcement Team when
+necessary.
+
+The current PyMCon Diversity Committee consists of:
+
+* Oriol Abril-Pla, Diversity Chair
+  - oriol.abril.pla@gmail.com
+* Alexandre Andorra, Diversity Chair
+  - andorra.alexandre@gmail.com
+
+### Conflicts of Interest
+
+In the event of any conflict of interest, the committee member will immediately notify
+and recuse themselves if necessary.
+
+If you are concerned about making a report that will be read by any of the above
+individuals, please reach out to [PyMCon's executive committee]() or to one of the members
+of the [NumFOCUS Board](https://www.numfocus.org/people#people-directors).
+
+### Appealing a Decision
+
+To appeal a decision, contact Oriol Abril-Pla at oriol.abril.pla@gmail.com with your
+appeal and the Executive committee or the
+[NumFOCUS Board](https://www.numfocus.org/people#people-directors) will review the case.
+
+### Timeline Summary:
+##### Confirming Receipt
+
+The Diversity Committee will make every effort to acknowledge receipt of a report within
+24 hours (and we’ll aim for much more quickly than that).
+
+##### Reviewing the Report
+
+We will make all efforts to review the incident within three days.
+
+##### Consequences & Resolution
+
+We aim to respond within one week to the original reporter with either a resolution or
+an explanation of why the situation is not yet resolved.
+
+## Issue Log
+
+A summary of reported incidents will be provided after the event.
+
+READ THE COMPLETE NUMFOCUS CODE OF CONDUCT
+
+<style>.centered {text-align: center;}</style>
+<div class="centered">
+  <a href="https://numfocus.org/code-of-conduct">
+    <button type="button" class="btn btn-xl">Code of Conduct</button>
+  </a>
+</div>
+
+For sections that are present both in this page and in NumFOCUS complete Code of Conduct
+such as "how to report" or "Appealing a Decision", the directives here take precedence.
+
+This page has been adapted from numerous sources, mainly [PyData Code of
+Conduct](https://pydata.org/code-of-conduct/) and [JupyterCon Code of
+Conduct](https://jupytercon.com/codeofconduct/)


### PR DESCRIPTION
Add code of conduct to website. fixes #9

I have written in markdown which is not rendered correctly in the website even though it's jekyll powered. Once the content is final, we can work on formatting.

tagging @twiecki @sidravi1 @canyon289 @AlexAndorra 