### PR TITLE
Hard code links for deploy as a hack for now

### DIFF
--- a/_includes/2017_data/header-home.html
+++ b/_includes/2017_data/header-home.html
@@ -19,7 +19,9 @@
                         <a href="/"></a>
                     </li>
                     <li>
-                        <a href="{{prepend: site.baseurl }}/cfp">CFP</a>
+            <!-- Hard coding because I cant figure out the base url and its late                        -->
+            <!--                        <a href="{{prepend: site.baseurl}}/cfp">CFP</a>-->
+                        <a href="https://pymc-devs.github.io/pymcon/cfp">CFP</a>
                     </li>
                     <li>
                         <!--This tag has to be speakers because it's the only way the
@@ -33,7 +35,9 @@
                         <a class="page-scroll" href="#contact">Contact</a>
                     </li>
                     <li>
-                        <a href="{{prepend: site.baseurl }}/code_of_conduct">Code of Conduct</a>
+                        <!-- Hard coding because I cant figure out the base url and its late            -->
+                        <!--                        <a href="{{prepend: site.baseurl}}/cfp">CFP</a>-->
+                        <a href="https://pymc-devs.github.io/pymcon/code_of_conduct">Code of Conduct</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
@sidravi1 @OriolAbril 

Could use some help figuring out sometime but right now am too tired to know what's going on

In short, things work locally, but when you deploy the base url is not getting the `pymcon` subpath. Self merging so the site works and isn't broken but need to come back and fix

![image](https://user-images.githubusercontent.com/7213793/89116840-63ca6400-d44d-11ea-810b-7ececdf811c0.png)
