### PR TITLE
Converted CoC to html / fixed header

### DIFF
--- a/_2017_pages/cfp.html
+++ b/_2017_pages/cfp.html
@@ -7,22 +7,22 @@ title: Call for proposals is now open
 
     <section id="conference" class="cfp cfp-container cfp-container-top">
       <h1>{{ page.title }}</h1>
-      <div class="normal-text">
+      <div >
          <a href ="https://forms.gle/uHcTE53bpUYPHHJ79" class="btn btn-sm normal-text">Click here to submit</a>
       </div>
 
       <h2 class="first">Key Dates</h2>
-      <p class = "normal-text">Deadline for CFP: September 4th Anywhere on Earth</p>
-      <p class = "normal-text">Date of final submission: TBD Likely first week of October</p>
+      <p>Deadline for CFP: September 4th Anywhere on Earth</p>
+      <p>Date of final submission: TBD Likely first week of October</p>
 
       <h2 class="first">Format</h2>
-      <p class = "normal-text">
+      <p>
       PyMCon 2020 is asynchronous first conferences. All contributors will be submitted a video or code
       ahead of time. which will be posted in a TBD place (probably Youtube)
       </p>
 
       <h2 class="first">What we are looking for</h2>
-      <p class="normal-text">
+      <p>
         We are looking for folks like you to share your cool tricks, best practices,
         and general knowledge with the Bayesian community. This conference will have two
         tracks, a "Conjugate Model" track for folks just getting started out, and "No U turn Sampler"
@@ -30,7 +30,7 @@ title: Call for proposals is now open
         (Track names  and puns subject to change).
       </p>
 
-      <p class=normal-text>
+      <p>
           There are three formats we're looking for specifically
       </p>
 

--- a/_2017_pages/code_of_conduct.md
+++ b/_2017_pages/code_of_conduct.md
@@ -4,186 +4,259 @@ title: PyMCon Code of Conduct
 permalink: /code_of_conduct
 ---
 
-# Code of Conduct
+<section id="conference" class="cfp cfp-container cfp-container-top">
+  <h1>{{ page.title }}</h1>
+  <p class="normal-text">
+    PyMCon abides by the NumFOCUS Code of Conduct.
+  </p>
 
-PyMCon abides by the NumFOCUS Code of Conduct.
+  <style>.centered {text-align: center;}</style>
+  <div class="centered">
+    <a href="https://numfocus.typeform.com/to/kMgloi8t">
+       <button type="button" class="btn btn-warning btn-lg">Report a Code of Conduct Incident</button>
+    </a>
+  </div>
 
-<style>.centered {text-align: center;}</style>
-<div class="centered">
-  <a href="https://numfocus.typeform.com/to/kMgloi8t">
-    <button type="button" class="btn btn-warning btn-lg">Report a Code of Conduct Incident</button>
-  </a>
-</div>
 
+<p class="normal-text">
 We value the participation of each member of the PyMC community and want all attendees to
 have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to
 show respect and courtesy to other attendees throughout the conference and at all
 conference events, whether officially sponsored by PyMC or not.
-
+</p>
+<p>
 To make clear what is expected, all delegates, speakers, exhibitors and volunteers at
 PyMCon event are required to conform to the NumFOCUS Code of Conduct. Organizers will
 enforce this code throughout the event.
-
+</p>
+<p>
 We reproduce here certain portions of the NumFOCUS Code of Conduct that are specifically
 relevant to PyMCon. We encourage all PyMCon participants to review the complete
 Code of Conduct.
+</p>
 
-## The Shorter Version
-
+<h2 class="first">The Shorter Version</h2>
+<p class="normal-text">
 Be kind to others. Do not insult or put down others. Behave professionally. Remember that
 harassment and sexist, racist, or exclusionary jokes and language are not appropriate for
 PyMCon.
-
-All communication should be appropriate for a professional audience including people of
+</p>
+<p>All communication should be appropriate for a professional audience including people of
 many different backgrounds. Sexual language and imagery is not appropriate.
-
-PyMCon is dedicated to providing a harassment-free event experience for everyone,
+</p>
+<p>PyMCon is dedicated to providing a harassment-free event experience for everyone,
 regardless of gender, sexual orientation, gender identity, and expression, disability,
 physical appearance, body size, race, or religion. We do not tolerate harassment of
 participants in any form.
-
+</p>
+<p>
 Thank you for helping make this a welcoming, friendly community for all.
+</p>
 
-## Code of Conduct Highlights Specific to PyMCon
-
+<h2 class="first">Code of Conduct Highlights Specific to PyMCon</h2>
+<p>
 We reproduce here certain portions of the NumFOCUS Code of Conduct that are specifically
 relevant to PyMCon. We encourage all PyMCon participants to review the complete Code of
 Conduct.
-
-### How to Report
-
+</p>
+<h3> How to Report </h3>
+<p>
 If you believe someone is violating the Code of Conduct, please report this in a timely
 manner. Code of Conduct violations reduce the value of the community for everyone and we
 take them seriously.
+</p>
 
+<p>
 You can make a personal or anonymous report by:
-
-* **By Email**: Send a message to any or all Diversity Chairs, which can be reached at
+</p>
+<p>
+<li><b>Email</b>: Send a message to any or all Diversity Chairs,who can be reached at
   oriol.abril.pla@gmail.com and andorra.alexandre@gmail.com. Event organizers will respond
   promptly.
-* **On Slack**: Join the [PyMCon Slack](https://pymcon.slack.com/join/shared_invite/zt-fk9efmvb-SWvT01TOnykgzFmLgn1iAw)
-  and contact with the Diversity Chairs, Oriol Abril or Alex Andorra.
-* **Online Form**: A variant of the NumFOCUS Code of Conduct Report is available for
-  PyMCon [here](https://numfocus.typeform.com/to/kMgloi8t) (your name and contact
-  information are not required).
+</li>
 
+<li>
+<b>Slack</b>: Join the <a href="https://pymcon.slack.com/join/shared_invite/zt-fk9efmvb-SWvT01TOnykgzFmLgn1iAw">PyMCon Slack</a>
+  and contact the Diversity Chairs, Oriol Abril or Alex Andorra.
+</li>
+<li>
+<b>Online Form</b>: A variant of the NumFOCUS Code of Conduct Report is available for
+  PyMCon <a href="https://numfocus.typeform.com/to/kMgloi8t">here</a> (your name and contact
+  information are not required).
+</li>
+</p>
+
+<p>
 During PyMCon, we recommend contacting via email or Slack so we can take
 immediate action if necessary. In addition to contacting directly with the Diversity
 committee, we also encourages you to make a report using our reporting form.
+</p>
 
-To file a report anonymously please use the [online form](https://numfocus.typeform.com/to/kMgloi8t).
-
-### What to include in a report
-
+<p>
+To file a report anonymously please use the <a href="https://numfocus.typeform.com/to/kMgloi8t">online form</a>
+</p>
+<h3>What to include in a report</h3>
+<p>
 Our ability to address any Code of Conduct breaches in a timely and effective manner
 is impacted by the amount of information you can provide, so our reporting form asks you
 to include as much of the following information as you can:
+</p>
 
-* Your contact info (so we can get in touch with you if we need to follow up). This will
+<li>
+Your contact info (so we can get in touch with you if we need to follow up). This will
   be kept confidential. If you wish to remain anonymous, your information will not be
   shared beyond the person receiving the initial report.
-* The approximate time and location of the incident (please be as specific as possible)
-* Identifying information (e.g. name, nickname, screen name, physical description) of the
+</li>
+<li>
+The approximate time and location of the incident (please be as specific as possible)
+</li>
+<li>
+Identifying information (e.g. name, nickname, screen name, physical description) of the
   individual whose behavior is being reported
-* Description of the behavior (if reporting harassing language, please be specific about
+</li>
+<li>
+Description of the behavior (if reporting harassing language, please be specific about
   the words used), your account of what happened, and any available supporting records
   (e.g. email, GitHub issue, screenshots, etc.). The online form supports
   attaching up to 5 files and email and Slack have not limit.
-* Description of the circumstances/context surrounding the incident. Let us know if the
+</li>
+<li>
+Description of the circumstances/context surrounding the incident. Let us know if the
   incident is ongoing, and/or if this is part of an ongoing pattern of behavior
-* Names and contact info, if possible, of anyone else who witnessed or was involved in
+</li>
+<li>
+Names and contact info, if possible, of anyone else who witnessed or was involved in
   this incident. (Did anyone else observe the incident?)
-* Any other relevant information you believe we should have
-
-_The Diversity committee will attempt to gather and write down the above information from
+</li>
+<li>
+Any other relevant information you believe we should have
+</li>
+<p>
+<em>
+The Diversity committee will attempt to gather and write down the above information from
 anyone making a verbal report. Recording the details in writing is exceedingly important
 in order for us to effectively respond to reports. If event staff write down a report
 taken verbally, then the person making the report will be asked to review the written
-report for accuracy._
-
-### Enforcement
-
+report for accuracy.
+</em>
+</p>
+<h3>Enforcement</h3>
+<p>
 At PyMCon, if a participant engages in behavior that violates the Code of Conduct, the
 conference organizers and staff may take any action they deem appropriate.
-
+</p>
+<p>
 Potential consequences for violating the NumFOCUS Code of Conduct at PyMCon include:
-
-* Warning the person to cease their behavior and that any further reports will result in
+</p>
+<li>
+Warning the person to cease their behavior and that any further reports will result in
   sanctions
-* Requiring that the person avoid any interaction with the person they are harassing for
+</li>
+<li>
+Requiring that the person avoid any interaction with the person they are harassing for
   the remainder of the event
-* Ending a talk that violates the policy early
-* Not publishing the video or slides of a talk that violated the policy
-* Not allowing a speaker who violated the policy to give (further) talks at the event
+</li>
+<li>
+Ending a talk that violates the policy early
+</li>
+<li>
+Not publishing the video or slides of a talk that violated the policy
+</li>
+<li>
+Not allowing a speaker who violated the policy to give (further) talks at the event
   now or in the future
-* Immediately ending any event volunteer responsibilities and privileges the reported
+</li>
+<li>
+Immediately ending any event volunteer responsibilities and privileges the reported
   person holds
-* Requiring that the person not volunteer for future events (either indefinitely or for
+</li>
+<li>
+Requiring that the person not volunteer for future events (either indefinitely or for
   a certain time period)
-* Expelling the person from the event without a refund
-* Banning the person from future events (either indefinitely or for a certain time period)
-* Any other response that the organizing committee deems necessary and appropriate to
+</li>
+<li>
+Expelling the person from the event without a refund
+</li>
+<li>
+Banning the person from future events (either indefinitely or for a certain time period)
+</li>
+<li>
+Any other response that the organizing committee deems necessary and appropriate to
   the situation
-
-### Person(s) Responsible for Resolving Complaints
-
+</li>
+<h3>Person(s) Responsible for Resolving Complaints</h3>
+<p>
 All reports of breaches of the code of conduct will be investigated and handled by the
 PyMCon Diversity Committee, consulting the NumFOCUS Code of Conduct Enforcement Team when
 necessary.
-
+</p>
+<p>
 The current PyMCon Diversity Committee consists of:
-
-* Oriol Abril-Pla, Diversity Chair
+</p>
+<li>
+Oriol Abril-Pla, Diversity Chair
   - oriol.abril.pla@gmail.com
-* Alexandre Andorra, Diversity Chair
+</li>
+<li>
+Alexandre Andorra, Diversity Chair
   - andorra.alexandre@gmail.com
+</li>
 
-### Conflicts of Interest
-
+<h3> Conflicts of Interest</h3>
+<p>
 In the event of any conflict of interest, the committee member will immediately notify
 and recuse themselves if necessary.
-
+</p>
+<p>
 If you are concerned about making a report that will be read by any of the above
-individuals, please reach out to [PyMCon's executive committee]() or to one of the members
-of the [NumFOCUS Board](https://www.numfocus.org/people#people-directors).
-
-### Appealing a Decision
-
+individuals, please reach out to <a href="#">PyMCon's executive committee</a> or to one of the members
+of the <a href="https://www.numfocus.org/people#people-directors">NumFOCUS Board</a>
+</p>
+<h3>Appealing a Decision</h3>
+<p>
 To appeal a decision, contact Oriol Abril-Pla at oriol.abril.pla@gmail.com with your
 appeal and the Executive committee or the
-[NumFOCUS Board](https://www.numfocus.org/people#people-directors) will review the case.
+<a href="https://www.numfocus.org/people#people-directors">NumFOCUS Board</a> will review the case.
+</p>
 
-### Timeline Summary:
-##### Confirming Receipt
+<h3>Timeline Summary:</h3>
+<p>
+<b>Confirming Receipt</b>
+</p>
 
+<p>
 The Diversity Committee will make every effort to acknowledge receipt of a report within
 24 hours (and we’ll aim for much more quickly than that).
+</p>
 
-##### Reviewing the Report
+<p>
+<b>Reviewing the Report</b>
+</p>
+<p>We will make all efforts to review the incident within three days.</p>
 
-We will make all efforts to review the incident within three days.
-
-##### Consequences & Resolution
-
+<p><b>Consequences & Resolution</b><p>
+<p>
 We aim to respond within one week to the original reporter with either a resolution or
 an explanation of why the situation is not yet resolved.
+</p>
 
-## Issue Log
-
+<h2>Issue Log</h2>
+<p>
 A summary of reported incidents will be provided after the event.
-
+</p>
+<p>
 READ THE COMPLETE NUMFOCUS CODE OF CONDUCT
-
+</p>
 <style>.centered {text-align: center;}</style>
 <div class="centered">
   <a href="https://numfocus.org/code-of-conduct">
     <button type="button" class="btn btn-xl">Code of Conduct</button>
   </a>
 </div>
-
+<p>
 For sections that are present both in this page and in NumFOCUS complete Code of Conduct
 such as "how to report" or "Appealing a Decision", the directives here take precedence.
-
-This page has been adapted from numerous sources, mainly [PyData Code of
-Conduct](https://pydata.org/code-of-conduct/) and [JupyterCon Code of
-Conduct](https://jupytercon.com/codeofconduct/)
+</p>
+<p>
+This page has been adapted from numerous sources, mainly <a href="https://pydata.org/code-of-conduct/">PyData Code of
+Conduct</a> and <a href="https://jupytercon.com/codeofconduct/">JupyterCon Code of Conduct</a>.</p>

--- a/_includes/2017_data/header-home.html
+++ b/_includes/2017_data/header-home.html
@@ -19,9 +19,7 @@
                         <a href="/"></a>
                     </li>
                     <li>
-            <!-- Hard coding because I cant figure out the base url and its late                        -->
-            <!--                        <a href="{{prepend: site.baseurl}}/cfp">CFP</a>-->
-                        <a href="https://pymc-devs.github.io/pymcon/cfp">CFP</a>
+                        <a href="./cfp">CFP</a>
                     </li>
                     <li>
                         <!--This tag has to be speakers because it's the only way the
@@ -29,15 +27,12 @@
                         <a class="page-scroll" href="#speakers">Organizers</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#about">About</a>
-                    </li>
-                    <li>
                         <a class="page-scroll" href="#contact">Contact</a>
                     </li>
                     <li>
                         <!-- Hard coding because I cant figure out the base url and its late            -->
                         <!--                        <a href="{{prepend: site.baseurl}}/cfp">CFP</a>-->
-                        <a href="https://pymc-devs.github.io/pymcon/code_of_conduct">Code of Conduct</a>
+                        <a href="./code_of_conduct">Code of Conduct</a>
                     </li>
                 </ul>
             </div>

--- a/_includes/2017_data/header.html
+++ b/_includes/2017_data/header.html
@@ -19,13 +19,19 @@
                         <a href="/"></a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="./#speakers">Speakers</a>
+                        <a href="./cfp">CFP</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="./#about">About</a>
+                        <!--This tag has to be speakers because it's the only way the
+                            css works for the planning committee thumbnails-->
+                        <a href="./#speakers">Organizers</a>
+                    <li>
+                        <a href="./#contact">Contact</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="./#contact">Contact</a>
+                        <!-- Hard coding because I cant figure out the base url and its late            -->
+                        <!--                        <a href="{{prepend: site.baseurl}}/cfp">CFP</a>-->
+                        <a href="./code_of_conduct">Code of Conduct</a>
                     </li>
                 </ul>
             </div>

--- a/_sass/2016_sass/_cfp.scss
+++ b/_sass/2016_sass/_cfp.scss
@@ -7,28 +7,22 @@
     }
     h1 {
         color: #2185d0;
-        padding: 5px 5px 5px 10px;
-        -webkit-clip-path: polygon(0 0, 100% 0, 95% 100%, 0 100%);
-        clip-path: polygon(0 0, 100% 0, 85% 100%, 0 100%);
+        padding: 5px 5px 5px 0px;
         width: 90%;
     }
     h2 {
         color: #111111;
-        padding: 5px 5px 5px 10px;
-        -webkit-clip-path: polygon(0 0, 100% 0, 85% 100%, 0 100%);
-        clip-path: polygon(0 0, 100% 0, 85% 100%, 0 100%); 
+        padding: 5px 5px 5px 0px;
         width: 80%;
     }
     h3 {
         color: #627E93;
-        padding: 5px 5px 5px 10px;
-        -webkit-clip-path: polygon(0 0, 100% 0, 85% 100%, 0 100%);
-        clip-path: polygon(0 0, 100% 0, 85% 100%, 0 100%);
+        padding: 5px 5px 5px 0px;
         width:80%
     }
 }
 .cfp p {
-     padding: 0px 0px 0px 10px;
+     padding: 0px 0px 0px 0px;
 }
 .cfp-container-top {
   margin-top: 100px;


### PR DESCRIPTION
* CoC is now in html and uses same style as CFP
* FIxed header to have same links on other pages
* Remove About from the header since we aren't using that
* Fixed some typos that Alex picked up