### PR TITLE
Added speakers page

### DIFF
--- a/_2017_pages/schedule.html
+++ b/_2017_pages/schedule.html
@@ -10,7 +10,7 @@ description: "Stay tuned for updates!"
       <h1>{{ page.title }}</h1>
       <div class="table-responsive">
         <table class="table table-hover">
-          <thead class="thead-dark">
+          <thead class="thead-dark" style="text-align:center;">
             <tr>
               <th scope="col">Time</th>
               <th scope="col">Track 1</th>
@@ -21,18 +21,16 @@ description: "Stay tuned for updates!"
           <tbody>
             <tr>
               <th scope="row">9:30 AM</th>
-              <td rowspan="2"></td>
-              <td rowspan="2" class="table-warning">Welcome and Orientation</td>
-              <td rowspan="2"></td>
+              <td rowspan="2" colspan="3" style="text-align:center;" class="table-warning">Welcome and Orientation</td>
             </tr>
             <tr class="table-light">
               <th scope="row">9:45 AM</th>
             </tr>
             <tr >
               <th scope="row">10:00 AM</th>
-              <td rowspan="3"></td>
-              <td rowspan="3" class="table-success">Keynote 1<br>Chris Fonnesbeck</td>
-              <td rowspan="3"></td>
+              <td rowspan="3" colspan="3", class="table-success" style="text-align:center;">
+                  <b>Keynote 1</b><br>Chris Fonnesbeck
+              </td>
             </tr>
             <tr class="table-light">
               <th scope="row">10:15 AM</th>
@@ -42,9 +40,9 @@ description: "Stay tuned for updates!"
             </tr>
             <tr>
               <th scope="row">10:45 AM</th>
-              <td rowspan="3"></td>
-              <td rowspan="3" class="table-primary">Keynote 2<br>TBD</td>
-              <td rowspan="3"></td>
+              <td rowspan="3" colspan="3", class="table-primary" style="text-align:center;">
+                  <b>Keynote 2</b><br>TBD
+              </td>
             </tr>
             <tr class="table-light">
               <th scope="row">11:00 AM</th>
@@ -54,9 +52,9 @@ description: "Stay tuned for updates!"
             </tr>
             <tr>
               <th scope="row">11:30 AM</th>
-              <td rowspan="4" class="table-active"></td>
-              <td rowspan="4" class="table-active">Lunch Hour</td>
-              <td rowspan="4" class="table-active"></td>
+              <td rowspan="4" colspan="3", class="table-active" style="text-align:center;">
+                    Lunch Hour
+              </td>
             </tr>
             <tr class="table-light">
               <th scope="row">11:45 AM</th>
@@ -104,9 +102,9 @@ description: "Stay tuned for updates!"
             </tr>
             <tr>
               <th scope="row">3:00 PM</th>
-              <td rowspan="3"></td>
-              <td rowspan="3" class="table-danger">Keynote 3<br>TBD</td>
-              <td rowspan="3"></td>
+              <td rowspan="3" colspan="3", class="table-danger" style="text-align:center;">
+                    <b>Keynote 3</b><br>TBD
+              </td>
             </tr>
             <tr class="table-light">
               <th scope="row">3:15 PM</th>

--- a/_2017_pages/schedule.html
+++ b/_2017_pages/schedule.html
@@ -7,8 +7,12 @@ description: "Stay tuned for updates!"
     <!--background color-->
 
     <section id="conference" class="cfp cfp-container cfp-container-top">
-      <h1>{{ page.title }}</h1>
-      <div class="table-responsive">
+      <div class="row">
+            <div class="col-lg-12 text-center">
+                <h2 class="section-heading" style="width:100%"  >{{ page.title }}</h2>
+            </div>
+      </div>
+      <div class="table-responsive col-lg-12">
         <table class="table table-hover">
           <thead class="thead-dark" style="text-align:center;">
             <tr>

--- a/_2017_pages/speakers.html
+++ b/_2017_pages/speakers.html
@@ -5,5 +5,5 @@ title: Speakers
 description: "Check out the amazing roster of presenters at PyMCon 2020!"
 ---
 
-    {% include 2017_data/speakers.html %}
+    {% include 2017_data/speakers_page.html %}
     {% include 2017_data/speakers_info.html %}

--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -9,6 +9,8 @@
   alt: Chris
   topic:
   description: Chris is a Senior Quantitative Analyst in Baseball Operations for the New York Yankees. He is interested in computational statistics, machine learning, Bayesian methods, and applied decision analysis. He hails from Vancouver, Canada and received his Ph.D. from the University of Georgia.
+  presentation_type: Keynote
+  track: All
 
 - title: Viola Priesemann
   name: viola-priesemann
@@ -21,6 +23,8 @@
   alt: Viola
   topic:
   description: Viola heads a research team at the Max Planck Institute for Dynamics and Self-Organization. She investigates the self-organization of spreading dynamics in the brain to understand the emergence of living computation. With the outbreak of COVID-19, she adapted these mathematical approaches to infer and predict the spread of SARS-CoV-2, and to investigate mitigation strategies. Viola is board member of the Campus Institute for Data Science and Fellow of the Schiemann Kolleg.
+  presentation_type: Keynote
+  track: All
 
 - title: Aki Vehtari
   name: aki-vehtari
@@ -35,5 +39,7 @@
   alt: Aki
   topic:
   description:
+  presentation_type: Keynote
+  track: All
 
 # files in css/2017_style/img

--- a/_includes/2017_data/header-home.html
+++ b/_includes/2017_data/header-home.html
@@ -22,7 +22,7 @@
                         <a href="./cfp">CFP</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#speakers">Speakers</a>
+                        <a href="speakers">Speakers</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="#organizers">Organizers</a>

--- a/_includes/2017_data/header.html
+++ b/_includes/2017_data/header.html
@@ -22,7 +22,7 @@
                       <a href="{{ "./cfp" | absolute_url }}">CFP</a>
                     </li>
                     <li>
-                      <a href="{{ "./#speakers" | absolute_url }}">Speakers</a>
+                      <a href="{{ "./speakers" | absolute_url }}">Speakers</a>
                     </li>
                     <li>
                         <a href="{{ "./#organizers" | absolute_url }}">Organizers</a>

--- a/_includes/2017_data/speaker.html
+++ b/_includes/2017_data/speaker.html
@@ -1,7 +1,8 @@
 <h2>{{ page.title }}</h2>
 <p class="text-muted">{{ page.subtitle }}</p>
 <hr class="star-primary">
-<img src="{{ "./css/2017_style/img/speakers/speaker_image" | replace: 'speaker_image', page.image | absolute_url }}" class="img-responsive img-centered" alt="{{ page.alt }}">
+<img src="{{ "./css/2017_style/img/speakers/speaker_image" | replace: 'speaker_image', 
+                page.image | absolute_url }}" class="img-responsive img-centered" alt="{{ page.alt }}">
 
 {% if page.twitter %}
   <p><b>Twitter:</b> <a href="https://twitter.com/{{ page.twitter }}">@{{ page.twitter }}</a></p>

--- a/_includes/2017_data/speakers_page.html
+++ b/_includes/2017_data/speakers_page.html
@@ -1,0 +1,59 @@
+<!-- Portfolio Grid Section -->
+    <section id="speakers" class="speakers">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <h2 class="section-heading" style="width:100%">Speakers</h2>
+                <h3></h3>
+            </div>
+        <div class="table-responsive">
+            <table class="table table-hover " style = "width:90%; margin-left:auto; margin-right:auto;">
+          <thead class="thead-dark" style="text-align:center">
+            <tr>
+              <th scope="col">Speakers</th>
+              <th scope="col">Description</th>
+              <th scope="col">Proposal Type</th>
+              <th scope="col">Track</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for speaker in site.data.speakers %}
+            <tr class = "table table-light">
+                <td>
+                    <div>
+                    <img src="./css/2017_style/img/speakers/{{ speaker.thumbnail }}" 
+                        style="max-width: 200px; margin-top: 30px" class="img-responsive img-centered" alt="">
+                    </div>
+                    <div class="row">
+                        <div class="speakers-caption"  style="text-align:center">
+                        <h3>{{ speaker.title }}</h3>
+                        <ul class="list-inline social-buttons">
+                          {% if speaker.twitter %}
+                            <li><a href="https://twitter.com/{{ speaker.twitter }}"><i class="fa fa-twitter"></i></a></li>
+                          {% endif %}
+                          {% if speaker.github %}
+                            <li><a href="https://github.com/{{ speaker.github }}"><i class="fa fa-github"></i></a></li>
+                          {% endif %}
+                          {% if speaker.web %}
+                            <li><a href="{{ speaker.web }}"><i class="fa fa-link"></i></a></li>
+                          {% endif %}
+                        </ul>
+                    </div>
+                    </div>
+                </td>
+                <td style="max-width:300px">
+                    <p class="text-muted">{{ speaker.subtitle }}</p>
+                    <p class="text-muted small">{{ speaker.description }}</p>
+                </td>
+                <td style="text-align:center;">
+                    <p class="text-muted small">{{ speaker.presentation_type }}</p>
+                </td>
+                <td style="text-align:center;">
+                    <p class="text-muted small">{{ speaker.track }}</p>
+                </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        </div>
+        </div>
+    </section>

--- a/_sass/2016_sass/_speakers.scss
+++ b/_sass/2016_sass/_speakers.scss
@@ -3,6 +3,8 @@
     margin: 100px 15vw 60px 15vw;
     img {
         width: 100%;
+        max-width: 100px;
+        margin-top: 100px;
     }
     a {
         color: darkblue;
@@ -16,6 +18,11 @@
     }
     p, ol {
         font-size: 110%;
+    }
+
+    table.center {
+        margin-left:auto; 
+        margin-right:auto;
     }
     h1 {
         text-shadow: 2px 2px black;
@@ -45,6 +52,7 @@
             font-size: 110%;
         }
     }
+
 }
 
 @media screen and (max-width : 1200px){


### PR DESCRIPTION
Looks like this

![image](https://user-images.githubusercontent.com/14125957/93660583-98ef3d80-fa1e-11ea-8762-ba36d04b6eff.png)

Button now goes to this page.

We may want to have different stuff showing on the page but should be easy to do (add data to yml and update liquid tags to use them).

Also, left the speakers on the main page for now thinking it might be nice to have our keynote speakers there. 