### PR TITLE
Make schedule ready to publish

### DIFF
--- a/_2017_pages/schedule.html
+++ b/_2017_pages/schedule.html
@@ -1,8 +1,8 @@
 ---
 layout: 2017_default
 permalink: /schedule
-title: Schedule of Events
-description: "Schedule of talks"
+title: "PyMCon 2020 Schedule"
+description: "PyMCon is packed with amazing talks and activities! Check out the full schedule!"
 ---
     <!--background color-->
 

--- a/_2017_pages/schedule.html
+++ b/_2017_pages/schedule.html
@@ -96,7 +96,7 @@ description: "PyMCon is packed with amazing talks and activities! Check out the 
               <th scope="row">12:30 PM</th>
               <th scope="row">5:30 AM</th>
               <td rowspan="9" class="table-primary">PyMC Sprints <br><b>(Room 1)</b></td>
-              <td class="table-warning">Sayam Kumar</td>
+              <td class="table-warning"><a href = "{{site.url}}/speakers#sayam-kumar-r">Sayam Kumar</a></td>
               <td class="table-danger"><a href = "{{site.url}}/speakers#vincent-warmerdam-r">Vincent D. Warmerdam</a> & <a href = "{{site.url}}/speakers#matthijs-brouns-r">Matthijs Brouns</a></td>
             </tr>
             <tr>
@@ -108,19 +108,19 @@ description: "PyMCon is packed with amazing talks and activities! Check out the 
             <tr>
               <th scope="row">12:50 PM</th>
               <th scope="row">5:50 AM</th>
-              <td class="table-warning"><a href = "{{site.url}}/speakers#ali-akbar-septiandari-r">Ali Akbar Septiandri</a></td>
+              <td class="table-warning"><a href = "{{site.url}}/speakers#ali-akbar-septiandri-r">Ali Akbar Septiandri</a></td>
               <td class="table-danger"><a href = "{{site.url}}/speakers#alex-andorra-r">Alex Andorra</a></td>
             </tr>
             <tr>
               <th scope="row">1:00 PM</th>
               <th scope="row">6:00 AM</th>
-              <td class="table-warning">Thomas Wiecki</td>
+              <td class="table-warning"><a href = "{{site.url}}/speakers#thomas-wiecki-r">Thomas Wiecki</a></td>
               <td class="table-danger"><a href = "{{site.url}}/speakers#tim-dodwell-r">Tim Dodwell</a>, <a href = "{{site.url}}/speakers#mikkel-lykkegaard-r">Mikkel Lykkegaard</a> ,<a href = "{{site.url}}/speakers#grigorios-mingas-r">Grigorios Mingas</a></td>
             </tr>
             <tr>
               <th scope="row">1:10 PM</th>
               <th scope="row">6:10 AM</th>
-              <td class="table-warning">Ivan Yashchuk</td>
+              <td class="table-warning"><a href = "{{site.url}}/speakers#ivan-yashchuk-r">Ivan Yashchuk</a></td>
               <td class="table-danger"><a href = "{{site.url}}/speakers#hessam-mehr-r">Hessam Mehr</a> and <a href = "{{site.url}}/speakers#dario-caramelli-r">Dario Caramelli</a></td>
             </tr>
             <tr>
@@ -221,7 +221,7 @@ description: "PyMCon is packed with amazing talks and activities! Check out the 
               <th scope="row">5:30 PM</th>
               <th scope="row">10:30 AM</th>
               <td rowspan="4" colspan="2" class="table-primary" style="text-align:center;">
-                  <b>Keynote 2</b><br>Aki Vehtari
+                  <b>Keynote 2</b><br><a href = "{{site.url}}/speakers#aki-vehtari-r">Aki Vehtari</a>
               </td>
             </tr>
             <tr class="table-light">

--- a/_includes/2017_data/header-home.html
+++ b/_includes/2017_data/header-home.html
@@ -19,6 +19,9 @@
                         <a href="/"></a>
                     </li>
                     <li>
+                        <a href="./schedule">Schedule</a>
+                    </li>
+                    <li>
                         <a href="./cfp">CFP</a>
                     </li>
                     <li>
@@ -31,8 +34,6 @@
                         <a class="page-scroll" href="#contact">Contact</a>
                     </li>
                     <li>
-                        <!-- Hard coding because I cant figure out the base url and its late            -->
-                        <!--                        <a href="{{prepend: site.baseurl}}/cfp">CFP</a>-->
                         <a href="./code_of_conduct">Code of Conduct</a>
                     </li>
                 </ul>

--- a/_includes/2017_data/header.html
+++ b/_includes/2017_data/header.html
@@ -19,6 +19,9 @@
                         <a href="/"></a>
                     </li>
                     <li>
+                      <a href="{{ "./schedule" | absolute_url }}">Schedule</a>
+                    </li>
+                    <li>
                       <a href="{{ "./cfp" | absolute_url }}">CFP</a>
                     </li>
                     <li>
@@ -31,8 +34,6 @@
                         <a href="{{ "./#contact" | absolute_url }}">Contact</a>
                     </li>
                     <li>
-                        <!-- Hard coding because I cant figure out the base url and its late            -->
-                        <!--                        <a href="{{prepend: site.baseurl}}/cfp">CFP</a>-->
                         <a href="{{ "./code_of_conduct" | absolute_url }}">Code of Conduct</a>
                     </li>
                 </ul>

--- a/_includes/2017_data/mission.html
+++ b/_includes/2017_data/mission.html
@@ -21,7 +21,7 @@
                     <li><p>Help folks find ways to contribute to PyMC, authentic to themselves</p></li>
                 </ul>
                 </p>
-            <h3 class="section-heading">PyMCon is a totally volunteer run conference with help from people like you. Sign up <a href="https://forms.gle/mdHHWva1gcB4PZfX9">here</a> to get involved</h3>
+            <h3 class="section-heading">PyMCon is a totally volunteer run conference with help from people like you.
             </div>
         </div>
 </section>

--- a/_layouts/2017_home.html
+++ b/_layouts/2017_home.html
@@ -16,9 +16,9 @@
                 <div class="intro-heading">PymCon 2020<br></div>
                 <div class="intro-lead-in">An asynchronous-first virtual conference for the Bayesian community</div>
                 <div class="intro-lead-in-sub">October 31st</div>
-                <div class="intro-lead-in-sub">Africa/Asia/Europe: 9-15 GMT+2 </div>
-                <div class="intro-lead-in-sub">Americas: 9-15 GMT-7 </div>
-                <div class="intro-lead-in-sub">Schedule coming soon</div>
+                <div class="intro-lead-in-sub">Africa/Asia/Europe: 9-15 UTC </div>
+                <div class="intro-lead-in-sub">Americas: 9-15 UTC-7 </div>
+                <div class="intro-lead-in-sub"><a href="./schedule">Schedule</a></div>
                 <!-- a href="./cfp" class="btn btn-info btn-lg btn-margins">Submit a proposal</a -->
                 <a href="mailto:pymconference@gmail.com?subject=PyMCon Sponsorship" class="btn btn-info btn-lg btn-margins">Sponsor</a>
                 <a href="https://www.eventbrite.com/e/pymcon-2020-tickets-121404065829" class="btn btn-margins btn-complementary btn-huge" >Register!</a>


### PR DESCRIPTION
We should probably still add the links to discourse to the schedule, but right now they won't work, so maybe it's better to wait and have the change ready to be merged as soon as we publish discourse links

I tested everything locally